### PR TITLE
[Encode.js] Fix parser to properly return href based on trailing '/' on domain extension

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var url = require('url');
+var parse = require('url-parse');
 
 var prefixes = require('./prefixes');
 var suffixes = require('./suffixes');
 
 module.exports = function (uri) {
-  var parsedUri = url.parse(uri);
+  var parsedUri = parse(uri);
   if (parsedUri.protocol !== 'http:' && parsedUri.protocol !== 'https:') {
     throw new Error('Only "http://" and "https://" URLs can be encoded');
   }
@@ -22,10 +22,6 @@ module.exports = function (uri) {
 
 function encode(parsedURL) {
   var data = parsedURL.href;
-
-  if (parsedURL.path === '/') {
-    data = data.slice(0, -1); // strip trailing slash
-  }
 
   data = replace(data, prefixes);
   data = replace(data, suffixes);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "test": "mocha -R spec test/",
     "cover": "istanbul cover ./node_modules/mocha/bin/_mocha --report html -- -R spec"
   },
+  "dependencies": {
+    "url-parse": "^1.0.2"
+  },
   "devDependencies": {
     "chai": "^2.3.0",
     "mocha": "^2.2.4"


### PR DESCRIPTION
Using node's url module to parse a URL would attach a '/'  to the domain extension even if the URL string passed in specifically excluded it.

This caused the wrong byte value to be returned based on the list of domain suffixes.

Parsing with url-parser instead fixes this problem and removing the conditional to strip the '/' solved the issue.

P.S. It looks like you have a duplicate module called `node-uri-beacon-uri-encoding`. I'm assuming both are the same? If so it might be best to conform them into one to avoid confusing.

Thanks.
